### PR TITLE
Colour PRs depending on state

### DIFF
--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/IndexController.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/IndexController.kt
@@ -92,7 +92,7 @@ class IndexController(private val gitHubService: GitHubService) {
         if (isDraft) {
             return CheckState.DRAFT
         }
-        commit.statusCheckRollup?.state ?: return CheckState.NONE
+        commit.statusCheckRollup ?: return CheckState.NONE
 
         return when (commit.statusCheckRollup.state) {
             CheckState.ERROR.name -> CheckState.ERROR

--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/IndexController.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/IndexController.kt
@@ -1,5 +1,6 @@
 package com.github.xalvarez.githubteamdashboard
 
+import com.github.xalvarez.githubteamdashboard.github.Commit
 import com.github.xalvarez.githubteamdashboard.github.GitHubService
 import com.github.xalvarez.githubteamdashboard.github.GithubDashboardData
 import com.github.xalvarez.githubteamdashboard.github.Review
@@ -56,7 +57,8 @@ class IndexController(private val gitHubService: GitHubService) {
                         it.author.login,
                         it.title,
                         repository.name,
-                        toReviewState(it.reviews)
+                        toReviewState(it.reviews),
+                        toCheckState(it.isDraft, it.commits.nodes.first().commit)
                     )
                 }
             }
@@ -84,5 +86,21 @@ class IndexController(private val gitHubService: GitHubService) {
                 }
             }
         return reviewState
+    }
+
+    private fun toCheckState(isDraft: Boolean, commit: Commit): CheckState {
+        if (isDraft) {
+            return CheckState.DRAFT
+        }
+        commit.statusCheckRollup?.state ?: return CheckState.NONE
+
+        return when (commit.statusCheckRollup.state) {
+            CheckState.ERROR.name -> CheckState.ERROR
+            CheckState.EXPECTED.name -> CheckState.EXPECTED
+            CheckState.FAILURE.name -> CheckState.FAILURE
+            CheckState.PENDING.name -> CheckState.PENDING
+            CheckState.SUCCESS.name -> CheckState.SUCCESS
+            else -> CheckState.NONE
+        }
     }
 }

--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/GitHubResponseBody.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/GitHubResponseBody.kt
@@ -59,7 +59,9 @@ data class PullRequestNode(
     val createdAt: LocalDateTime,
     val author: Author,
     val title: String,
-    val reviews: Review
+    val reviews: Review,
+    val isDraft: Boolean,
+    val commits: Commits
 )
 
 data class Author(
@@ -72,6 +74,22 @@ data class Review(
 
 data class ReviewNode(
     val state: String
+)
+
+data class Commits(
+     val nodes: List<CommitNode>
+)
+
+data class CommitNode(
+      val commit: Commit
+)
+
+data class Commit(
+      val statusCheckRollup: CommitStatusCheckState?
+)
+
+data class CommitStatusCheckState(
+      val state: String
 )
 
 const val ALERTS_URL_SUFFIX = "/network/alerts"

--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/GitHubService.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/GitHubService.kt
@@ -37,6 +37,16 @@ open class GitHubService(private val gitHubClient: GitHubClient, private val git
                           state
                         }
                       }
+                      isDraft
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            statusCheckRollup {
+                              state
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/models/CheckState.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/models/CheckState.kt
@@ -1,0 +1,5 @@
+package com.github.xalvarez.githubteamdashboard.github.models
+
+enum class CheckState {
+    NONE, DRAFT, ERROR, EXPECTED, FAILURE, PENDING, SUCCESS
+}

--- a/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/models/PullRequestModel.kt
+++ b/src/main/kotlin/com/github/xalvarez/githubteamdashboard/github/models/PullRequestModel.kt
@@ -6,5 +6,6 @@ data class PullRequestModel(
     val author: String,
     val title: String,
     val repositoryName: String,
-    val state: ReviewState
+    val state: ReviewState,
+    val checkState: CheckState
 )

--- a/src/main/resources/views/dashboard.html
+++ b/src/main/resources/views/dashboard.html
@@ -55,17 +55,27 @@
                         </tr>
                         </thead>
                         <tbody>
-                        <tr th:each="pullRequest,iterStat : ${pullRequests}">
-                            <th class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
-                            <td class="align-middle" th:switch="${pullRequest.state.name}">
-                                <img th:case="'APPROVED'" src="icons/check-circle.svg" alt="Approved" />
-                                <img th:case="'CHANGES_REQUESTED'" src="icons/x-circle.svg" alt="Declined" />
-                            </td>
-                            <td class="align-middle" th:text="${pullRequest.repositoryName}"></td>
-                            <td class="align-middle" th:text="${pullRequest.author}"></td>
-                            <td class="align-middle"><a th:href="${pullRequest.url}" th:text="${pullRequest.title}"></a></td>
-                            <td class="align-middle" th:text="${pullRequest.createdAt}"></td>
-                        </tr>
+                        <th:block th:each="pullRequest,iterStat : ${pullRequests}">
+                            <th:block th:switch="${pullRequest.checkState.name}">
+                                <tr th:case="'NONE'">
+                                <tr th:case="'DRAFT'" class="alert-dark">
+                                <tr th:case="'ERROR'" class="alert-danger">
+                                <tr th:case="'EXPECTED'" class="alert-warning">
+                                <tr th:case="'FAILURE'" class="alert-danger">
+                                <tr th:case="'PENDING'" class="alert-warning">
+                                <tr th:case="'SUCCESS'" class="alert-success">
+                            </th:block>
+                                    <th class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <td class="align-middle" th:switch="${pullRequest.state.name}">
+                                        <img th:case="'APPROVED'" src="icons/check-circle.svg" alt="Approved" />
+                                        <img th:case="'CHANGES_REQUESTED'" src="icons/x-circle.svg" alt="Declined" />
+                                    </td>
+                                    <td class="align-middle" th:text="${pullRequest.repositoryName}"></td>
+                                    <td class="align-middle" th:text="${pullRequest.author}"></td>
+                                    <td class="align-middle"><a th:href="${pullRequest.url}" th:text="${pullRequest.title}"></a></td>
+                                    <td class="align-middle" th:text="${pullRequest.createdAt}"></td>
+                                </tr>
+                        </th:block>
                         </tbody>
                     </table>
                 </div>

--- a/src/main/resources/views/dashboard.html
+++ b/src/main/resources/views/dashboard.html
@@ -61,16 +61,16 @@
                         </thead>
                         <tbody>
                         <th:block th:each="pullRequest,iterStat : ${pullRequests}">
-                            <th:block th:switch="${pullRequest.checkState.name}">
-                                <tr th:case="'NONE'">
-                                <tr th:case="'DRAFT'" class="alert-dark">
-                                <tr th:case="'ERROR'" class="alert-danger">
-                                <tr th:case="'EXPECTED'" class="alert-warning">
-                                <tr th:case="'FAILURE'" class="alert-danger">
-                                <tr th:case="'PENDING'" class="alert-warning">
-                                <tr th:case="'SUCCESS'" class="alert-success">
-                            </th:block>
-                                    <th class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
+                            <tr>
+                                <th:block th:switch="${pullRequest.checkState.name}">
+                                    <th th:case="'NONE'" class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'DRAFT'" class="align-middle alert-dark" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'ERROR'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'EXPECTED'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'FAILURE'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'PENDING'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
+                                    <th th:case="'SUCCESS'" class="align-middle alert-success" scope="row" th:text="${iterStat.index + 1}"></th>
+                                </th:block>
                                     <td class="align-middle" th:switch="${pullRequest.state.name}">
                                         <img th:case="'APPROVED'" src="icons/check-circle.svg" alt="Approved" />
                                         <img th:case="'CHANGES_REQUESTED'" src="icons/x-circle.svg" alt="Declined" />

--- a/src/main/resources/views/dashboard.html
+++ b/src/main/resources/views/dashboard.html
@@ -60,27 +60,25 @@
                         </tr>
                         </thead>
                         <tbody>
-                        <th:block th:each="pullRequest,iterStat : ${pullRequests}">
-                            <tr>
-                                <th:block th:switch="${pullRequest.checkState.name}">
-                                    <th th:case="'NONE'" class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'DRAFT'" class="align-middle alert-dark" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'ERROR'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'EXPECTED'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'FAILURE'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'PENDING'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
-                                    <th th:case="'SUCCESS'" class="align-middle alert-success" scope="row" th:text="${iterStat.index + 1}"></th>
-                                </th:block>
-                                    <td class="align-middle" th:switch="${pullRequest.state.name}">
-                                        <img th:case="'APPROVED'" src="icons/check-circle.svg" alt="Approved" />
-                                        <img th:case="'CHANGES_REQUESTED'" src="icons/x-circle.svg" alt="Declined" />
-                                    </td>
-                                    <td class="align-middle" th:text="${pullRequest.repositoryName}"></td>
-                                    <td class="align-middle" th:text="${pullRequest.author}"></td>
-                                    <td class="align-middle"><a th:href="${pullRequest.url}" th:text="${pullRequest.title}"></a></td>
-                                    <td class="align-middle" th:text="${pullRequest.createdAt}"></td>
-                                </tr>
-                        </th:block>
+                            <tr th:each="pullRequest,iterStat : ${pullRequests}">
+                            <th:block th:switch="${pullRequest.checkState.name}">
+                                <th th:case="'NONE'" class="align-middle" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'DRAFT'" class="align-middle alert-dark" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'ERROR'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'EXPECTED'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'FAILURE'" class="align-middle alert-danger" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'PENDING'" class="align-middle alert-warning" scope="row" th:text="${iterStat.index + 1}"></th>
+                                <th th:case="'SUCCESS'" class="align-middle alert-success" scope="row" th:text="${iterStat.index + 1}"></th>
+                            </th:block>
+                                <td class="align-middle" th:switch="${pullRequest.state.name}">
+                                    <img th:case="'APPROVED'" src="icons/check-circle.svg" alt="Approved" />
+                                    <img th:case="'CHANGES_REQUESTED'" src="icons/x-circle.svg" alt="Declined" />
+                                </td>
+                                <td class="align-middle" th:text="${pullRequest.repositoryName}"></td>
+                                <td class="align-middle" th:text="${pullRequest.author}"></td>
+                                <td class="align-middle"><a th:href="${pullRequest.url}" th:text="${pullRequest.title}"></a></td>
+                                <td class="align-middle" th:text="${pullRequest.createdAt}"></td>
+                            </tr>
                         </tbody>
                     </table>
                     <div th:if="${#lists.size(pullRequests) > 10}">

--- a/src/main/resources/views/dashboard.html
+++ b/src/main/resources/views/dashboard.html
@@ -43,6 +43,11 @@
             <div class="card text-center">
                 <div class="card-header">Open Pull Requests</div>
                 <div class="card-body">
+                    <span class="badge badge-secondary">Draft</span>
+                    <span class="badge badge-light">No check</span>
+                    <span class="badge badge-success">Successful check</span>
+                    <span class="badge badge-warning">Pending check</span>
+                    <span class="badge badge-danger">Failed check</span>
                     <table class="table">
                         <thead>
                         <tr>
@@ -78,6 +83,13 @@
                         </th:block>
                         </tbody>
                     </table>
+                    <div th:if="${#lists.size(pullRequests) > 10}">
+                        <span class="badge badge-secondary">Draft</span>
+                        <span class="badge badge-light">No check</span>
+                        <span class="badge badge-success">Successful check</span>
+                        <span class="badge badge-warning">Pending check</span>
+                        <span class="badge badge-danger">Failed check</span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/views/public/dashboard.js
+++ b/src/main/resources/views/public/dashboard.js
@@ -1,4 +1,4 @@
-const REFRESH_INTERVAL = 3000000
+const REFRESH_INTERVAL = 300000
 
 function refreshDashboard() {
   fetch("/dashboard")

--- a/src/main/resources/views/public/dashboard.js
+++ b/src/main/resources/views/public/dashboard.js
@@ -1,4 +1,4 @@
-const REFRESH_INTERVAL = 300000
+const REFRESH_INTERVAL = 3000000
 
 function refreshDashboard() {
   fetch("/dashboard")

--- a/src/test/kotlin/com/github/xalvarez/githubteamdashboard/IndexControllerTest.kt
+++ b/src/test/kotlin/com/github/xalvarez/githubteamdashboard/IndexControllerTest.kt
@@ -33,7 +33,7 @@ internal class IndexControllerTest {
     fun `should build model`() {
         givenSuccessfulGitHubServiceResponse()
         val expectedTeamModel = givenExpectedTeamModel()
-        val expectedAmountOfPullRequests = 3
+        val expectedAmountOfPullRequests = 7
 
         val response = indexController.dashboard()
         val model = response.body() as HashMap<*, *>
@@ -52,6 +52,18 @@ internal class IndexControllerTest {
         assertTrue { (pullRequests[2] as PullRequestModel).repositoryName == "example_repo_2" }
         assertTrue { (pullRequests[2] as PullRequestModel).state == CHANGES_REQUESTED }
         assertTrue { (pullRequests[2] as PullRequestModel).checkState == CheckState.NONE }
+        assertTrue { (pullRequests[3] as PullRequestModel).repositoryName == "example_repo_4" }
+        assertTrue { (pullRequests[3] as PullRequestModel).state == PENDING }
+        assertTrue { (pullRequests[3] as PullRequestModel).checkState == CheckState.EXPECTED }
+        assertTrue { (pullRequests[4] as PullRequestModel).repositoryName == "example_repo_5" }
+        assertTrue { (pullRequests[4] as PullRequestModel).state == PENDING }
+        assertTrue { (pullRequests[4] as PullRequestModel).checkState == CheckState.PENDING }
+        assertTrue { (pullRequests[5] as PullRequestModel).repositoryName == "example_repo_6" }
+        assertTrue { (pullRequests[5] as PullRequestModel).state == PENDING }
+        assertTrue { (pullRequests[5] as PullRequestModel).checkState == CheckState.SUCCESS }
+        assertTrue { (pullRequests[6] as PullRequestModel).repositoryName == "example_repo_7" }
+        assertTrue { (pullRequests[6] as PullRequestModel).state == PENDING }
+        assertTrue { (pullRequests[6] as PullRequestModel).checkState == CheckState.NONE }
         assertEquals(securityAlerts.size, 1)
         assertEquals((securityAlerts[0] as SecurityAlert).repository, "example_repo_2")
         assertEquals((securityAlerts[0] as SecurityAlert).url, "example.com/network/alerts")
@@ -95,6 +107,26 @@ internal class IndexControllerTest {
                     isDraft = false, commits = Commits(listOf(
                     CommitNode(Commit(CommitStatusCheckState("FAILURE")))
                 ))),
+                    "example.com", VulnerabilityAlerts(arePresent = false)),
+                Repository("example_repo_4", buildPullRequests(author, 2013,
+                    isDraft = false, commits = Commits(listOf(
+                        CommitNode(Commit(CommitStatusCheckState("EXPECTED")))
+                    ))),
+                    "example.com", VulnerabilityAlerts(arePresent = false)),
+                Repository("example_repo_5", buildPullRequests(author, 2014,
+                    isDraft = false, commits = Commits(listOf(
+                        CommitNode(Commit(CommitStatusCheckState("PENDING")))
+                    ))),
+                    "example.com", VulnerabilityAlerts(arePresent = false)),
+                Repository("example_repo_6", buildPullRequests(author, 2015,
+                    isDraft = false, commits = Commits(listOf(
+                        CommitNode(Commit(CommitStatusCheckState("SUCCESS")))
+                    ))),
+                    "example.com", VulnerabilityAlerts(arePresent = false)),
+                Repository("example_repo_7", buildPullRequests(author, 2016,
+                    isDraft = false, commits = Commits(listOf(
+                        CommitNode(Commit(CommitStatusCheckState("UNEXPECTED_STATE")))
+                    ))),
                     "example.com", VulnerabilityAlerts(arePresent = false))
             )
         )

--- a/src/test/resources/wiremock/__files/post_github_successful.json
+++ b/src/test/resources/wiremock/__files/post_github_successful.json
@@ -52,6 +52,16 @@
                     "title": "Add cool feature",
                     "reviews": {
                       "nodes": []
+                    },
+                    "isDraft": true,
+                    "commits": {
+                      "nodes": [
+                        {
+                          "commit": {
+                            "statusCheckRollup": null
+                          }
+                        }
+                      ]
                     }
                   },
                   {
@@ -68,6 +78,18 @@
                         },
                         {
                           "state": "CHANGES_REQUESTED"
+                        }
+                      ]
+                    },
+                    "isDraft": false,
+                    "commits": {
+                      "nodes": [
+                        {
+                          "commit": {
+                            "statusCheckRollup": {
+                              "state": "SUCCESS"
+                            }
+                          }
                         }
                       ]
                     }
@@ -94,6 +116,18 @@
                       "nodes": [
                         {
                           "state": "APPROVED"
+                        }
+                      ]
+                    },
+                    "isDraft": false,
+                    "commits": {
+                      "nodes": [
+                        {
+                          "commit": {
+                            "statusCheckRollup": {
+                              "state": "ERROR"
+                            }
+                          }
                         }
                       ]
                     }


### PR DESCRIPTION
Fixes https://github.com/xalvarez/github-team-dashboard/issues/106

This colours PRs depending on if they are drafts or if they have a check state.

I decided to include drafts in this solution because  in my opinion, although drafts may have check states, check states are irrelevant while a PR is still work in progress.

@henrik432 could you please checkout this branch and give me feedback about the suggested design? I wasn't sure about what could be the best way to represent this information but I think this PR achieves the desired outcome.